### PR TITLE
feat: add registration timeline and brochure CTA button

### DIFF
--- a/src/components/DateLine.astro
+++ b/src/components/DateLine.astro
@@ -1,0 +1,88 @@
+---
+import SparklesIcon from "~icons/lucide/sparkles";
+import RocketIcon from "~icons/lucide/rocket";
+import AlarmIcon from "~icons/ic/baseline-alarm";
+import CampaignIcon from "~icons/ic/baseline-campaign";
+import CoffeeIcon from "~icons/lucide/coffee";
+import timelineData from "@/data/registration-timeline.json";
+
+const iconMap = {
+	sparkles: SparklesIcon,
+	rocket: RocketIcon,
+	alarm: AlarmIcon,
+	campaign: CampaignIcon,
+	coffee: CoffeeIcon
+};
+
+const items = timelineData.items.map(item => ({
+	...item,
+	icon: iconMap[item.iconKey as keyof typeof iconMap]
+}));
+---
+
+<div
+	class="relative mt-(--gap)"
+	style="
+    --dot:    clamp(4rem, 6.5vw, 5.5rem);
+    --marker: clamp(0.875rem, 1.2vw, 1.125rem);
+    --stem:   clamp(0.625rem, 1.2vw, 1.125rem);
+    --line:   0.375rem;
+    --arrow:  0.875rem;
+    --end:    calc(var(--arrow) * 5);
+  "
+>
+	<!-- 桌機：水平線 + 右箭頭 -->
+	<div class="absolute hidden md:flex md:items-center" style="top:calc(var(--dot) + var(--stem) + var(--marker)/2); transform:translateY(-50%); left:0; right:0;" aria-hidden="true">
+		<div class="bg-background flex-1" style="height:var(--line)"></div>
+		<div
+			style="flex-shrink:0;width:0;height:0;
+             border-top:var(--arrow) solid transparent;
+             border-bottom:var(--arrow) solid transparent;
+             border-left:calc(var(--arrow)*1.5) solid var(--color-background)"
+		>
+		</div>
+	</div>
+
+	<!-- 桌機：節點清單 -->
+	<ul class="hidden list-none p-0 md:flex md:flex-row md:items-start md:justify-between" style="padding-right:var(--end)">
+		{
+			items.map(({ date, label, icon: Icon }) => (
+				<li class="flex flex-col items-center text-center">
+					<div class="bg-soft-blue relative z-10 flex shrink-0 items-center justify-center rounded-full text-white" style="width:var(--dot);height:var(--dot)">
+						<Icon class="h-[55%] w-[55%]" />
+					</div>
+					<div class="bg-soft-blue/40" style="width:0.125rem;height:var(--stem)" />
+					<div class="bg-soft-blue relative z-10 rounded-full" style="width:var(--marker);height:var(--marker)" />
+					<div class="mt-3 flex flex-col gap-1">
+						<span class="text-background text-[clamp(0.875rem,1.3vw,1.125rem)] leading-none font-bold opacity-60">{date}</span>
+						<span class="text-background text-[clamp(1.125rem,1.8vw,1.5rem)] leading-snug font-extrabold">{label}</span>
+					</div>
+				</li>
+			))
+		}
+	</ul>
+
+	<!-- 手機：左導軌 + icon 壓線 + 右側文字 -->
+	<div class="relative mt-(--gap) md:hidden" style="--rail: clamp(3rem, 28%, 5.5rem); --mdot: clamp(3.5rem, 14vw, 5rem)">
+		<!-- 導軌線 -->
+		<div class="bg-background/50 absolute top-0 bottom-0" style="left:var(--rail); transform:translateX(-50%); width:0.1875rem" aria-hidden="true"></div>
+
+		<ul class="flex list-none flex-col p-0" style="gap:clamp(3rem,11vw,5rem); padding-left:var(--rail)">
+			{
+				items.map(({ date, label, icon: Icon }) => (
+					<li class="flex items-center gap-8" style="margin-left:calc(var(--mdot) / -2)">
+						<div class="bg-soft-blue relative z-10 flex shrink-0 items-center justify-center rounded-full text-white" style="width:var(--mdot);height:var(--mdot)">
+							<Icon class="h-[55%] w-[55%]" />
+						</div>
+						<div class="flex flex-col gap-1.5">
+							<span class="text-background text-sm leading-none font-bold opacity-60">{date}</span>
+							<span class="text-background leading-snug font-extrabold" style="font-size:clamp(1.125rem,5.5vw,1.5rem)">
+								{label}
+							</span>
+						</div>
+					</li>
+				))
+			}
+		</ul>
+	</div>
+</div>

--- a/src/components/RegistrationInfo.astro
+++ b/src/components/RegistrationInfo.astro
@@ -5,6 +5,7 @@ import CalendarIcon from "~icons/ic/baseline-calendar-month";
 import TicketIcon from "~icons/ic/baseline-confirmation-number";
 import SchoolIcon from "~icons/ic/baseline-school";
 import homeData from "@/data/home.json";
+import DateLine from "@/components/DateLine.astro";
 
 const { registration } = homeData;
 const iconMap = {
@@ -53,6 +54,8 @@ const cards = registration.infoCards.map(card => ({
 			}
 		</div>
 
+		<DateLine variant="c" />
+
 		<div class="flex w-full flex-col items-start lg:flex-row" style="margin-top: var(--gap)">
 			<div class="flex w-full flex-col items-start lg:flex-691">
 				{
@@ -74,12 +77,22 @@ const cards = registration.infoCards.map(card => ({
 
 			<div class="relative mt-(--gap) aspect-565/410 w-full overflow-hidden lg:mt-0 lg:flex-565">
 				<Image src={registrationPhoto} alt={registration.photoAlt} class="absolute top-[6.585%] left-[7.434%] aspect-239/159 w-[85.133%] object-cover" loading="lazy" decoding="async" />
-				<a
-					href={registration.cta.href}
-					class="bg-green absolute bottom-[4.878%] left-[35.929%] flex h-[clamp(3rem,17.561%,4.5rem)] items-center justify-center rounded-2xl px-3 text-[clamp(1.125rem,2.25vw,2.125rem)] leading-[150%] font-extrabold text-white shadow-[clamp(0.25rem,0.53vw,0.5rem)_clamp(0.25rem,0.53vw,0.5rem)_0_0_var(--color-orange)]"
-				>
-					{registration.cta.label}
-				</a>
+				<div class="absolute right-[8%] bottom-[4.878%] left-[8%] flex justify-center gap-3">
+					<a
+						href={registration.cta.href}
+						class="bg-green flex h-[clamp(2.75rem,17.561%,4.5rem)] items-center justify-center rounded-2xl px-4 text-[clamp(1rem,2.25vw,2.125rem)] leading-[150%] font-extrabold text-white shadow-[clamp(0.25rem,0.53vw,0.5rem)_clamp(0.25rem,0.53vw,0.5rem)_0_0_var(--color-orange)]"
+					>
+						{registration.cta.label}
+					</a>
+					<a
+						href={registration.ctaBrochure.href}
+						target="_blank"
+						rel="noreferrer"
+						class="bg-background text-foreground flex h-[clamp(2.75rem,17.561%,4.5rem)] items-center justify-center rounded-2xl px-4 text-[clamp(1rem,2.25vw,2.125rem)] leading-[150%] font-extrabold shadow-[clamp(0.25rem,0.53vw,0.5rem)_clamp(0.25rem,0.53vw,0.5rem)_0_0_var(--color-orange)]"
+					>
+						{registration.ctaBrochure.label}
+					</a>
+				</div>
 			</div>
 		</div>
 

--- a/src/data/home.json
+++ b/src/data/home.json
@@ -303,6 +303,10 @@
 			"label": "立即報名",
 			"href": "/2026/#registration-info"
 		},
+		"ctaBrochure": {
+			"label": "報名簡章",
+			"href": "https://drive.google.com/file/d/1nxt-lYWAMnsK-QbwbbeIV7lTi9hcimTw/view"
+		},
 		"noticeTitle": "注意事項",
 		"infoCards": [
 			{

--- a/src/data/registration-timeline.json
+++ b/src/data/registration-timeline.json
@@ -1,0 +1,29 @@
+{
+	"items": [
+		{
+			"date": "5/1",
+			"label": "早鳥報名",
+			"iconKey": "sparkles"
+		},
+		{
+			"date": "5/5",
+			"label": "開始報名",
+			"iconKey": "rocket"
+		},
+		{
+			"date": "5/9",
+			"label": "截止報名",
+			"iconKey": "alarm"
+		},
+		{
+			"date": "5/10",
+			"label": "公告報名結果",
+			"iconKey": "campaign"
+		},
+		{
+			"date": "7/6 – 7/19",
+			"label": "營期",
+			"iconKey": "coffee"
+		}
+	]
+}


### PR DESCRIPTION
- 新增 DateLine 時間軸元件（桌機水平 / 手機垂直導軌雙版型）
- 新增 registration-timeline.json 儲存五個時間節點資料
- 在報名資訊區塊加入時間軸，置於資訊卡下方
- 新增「報名簡章」按鈕，與「立即報名」並排顯示
- 修正 DateLine 中 px 單位改為 rem