### PR TITLE
fix: fix pfp img size

### DIFF
--- a/src/components/StudentComment.astro
+++ b/src/components/StudentComment.astro
@@ -83,7 +83,7 @@ const videos = studentComment.video.map(video => {
 								data-comment-html={encodeURIComponent(c.renderedFullComment)}
 							>
 								<div class:list={["flex h-19 items-center gap-4 self-stretch rounded-t-4xl p-4", commentColorClassMap[c.color] ?? "bg-blue"]}>
-									<Image src={c.image} alt={studentComment.avatarAlt} class="aspect-square h-full w-auto rounded-full" />
+									<Image src={c.image} alt={studentComment.avatarAlt} class="aspect-square h-full w-auto rounded-full object-cover" />
 
 									<p class="text-[1.5rem] leading-[100%] font-bold text-white">{c.name}</p>
 


### PR DESCRIPTION
## Summary

This PR fixed the students' pfp size by setting `object-cover` class.
Relate Issue: #70 

## TDL

- [x] Add `object-class` to students' pfp image class

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved student comment avatar image rendering to properly fit square images within rounded avatar containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->