### PR TITLE
fix: fix students' comment align

### DIFF
--- a/src/components/StudentComment.astro
+++ b/src/components/StudentComment.astro
@@ -90,7 +90,7 @@ const videos = studentComment.video.map(video => {
 									<div />
 								</div>
 
-								<p class="text-background p-6 text-center text-[1rem] leading-[133%]">{c.comment}</p>
+								<p class="text-background p-6 text-left text-[1rem] leading-[133%]">{c.comment}</p>
 							</button>
 						))
 					}

--- a/src/components/StudentComment.astro
+++ b/src/components/StudentComment.astro
@@ -90,7 +90,7 @@ const videos = studentComment.video.map(video => {
 									<div />
 								</div>
 
-								<p class="text-background p-6 text-[1rem] leading-[133%]">{c.comment}</p>
+								<p class="text-background p-6 text-center text-[1rem] leading-[133%]">{c.comment}</p>
 							</button>
 						))
 					}


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Student comment cards: the preview text in the card body is now left-aligned instead of centered, improving readability.
  * No other user-visible behaviors changed — dialog interactions, embedded content handling, and full comment rendering remain the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->