### PR TITLE
feat: add mobile registration CTA

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -47,7 +47,6 @@ const { header } = layoutData;
 						</a>
 					))
 				}
-				<a class="site-header__mobile-cta" data-mobile-menu-link href={header.cta.href}>{header.cta.label}</a>
 			</nav>
 		</div>
 	</details>
@@ -290,8 +289,7 @@ const { header } = layoutData;
 
 	.site-header__link,
 	.site-header__cta,
-	.site-header__mobile-link,
-	.site-header__mobile-cta {
+	.site-header__mobile-link {
 		color: inherit;
 		font-weight: 800;
 		letter-spacing: 0;
@@ -323,24 +321,24 @@ const { header } = layoutData;
 		background: var(--color-soft-blue);
 		border-radius: clamp(0.8rem, 1.1vw, 1.15rem);
 		font-size: clamp(1rem, 1.25vw, 1.45rem);
+		box-shadow: 0.22rem 0.22rem 0 0 var(--color-orange);
 		transition:
 			background 160ms ease,
-			transform 160ms ease;
+			transform 160ms ease,
+			box-shadow 160ms ease;
 	}
 
 	.site-header__cta:hover,
-	.site-header__cta:focus-visible,
-	.site-header__mobile-cta:hover,
-	.site-header__mobile-cta:focus-visible {
+	.site-header__cta:focus-visible {
 		background: var(--color-sky-blue);
-		transform: translateY(-0.08rem);
+		transform: translate(-0.08rem, -0.08rem);
+		box-shadow: 0.34rem 0.34rem 0 0 var(--color-orange);
 	}
 
 	.site-header__link:focus-visible,
 	.site-header__cta:focus-visible,
 	.site-header__mobile-trigger:focus-visible,
-	.site-header__mobile-link:focus-visible,
-	.site-header__mobile-cta:focus-visible {
+	.site-header__mobile-link:focus-visible {
 		outline: 0.16rem solid var(--color-background);
 		outline-offset: 0.2rem;
 	}
@@ -420,8 +418,7 @@ const { header } = layoutData;
 		padding: 1rem;
 	}
 
-	.site-header__mobile-link,
-	.site-header__mobile-cta {
+	.site-header__mobile-link {
 		min-height: 3rem;
 		padding: 0.9rem 1rem;
 		border-radius: 0.8rem;
@@ -431,14 +428,6 @@ const { header } = layoutData;
 	.site-header__mobile-link:hover,
 	.site-header__mobile-link:focus-visible {
 		color: var(--color-soft-blue);
-	}
-
-	.site-header__mobile-cta {
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		color: var(--color-foreground);
-		background: var(--color-soft-blue);
 	}
 
 	@media (max-width: 52rem) {
@@ -452,13 +441,21 @@ const { header } = layoutData;
 			width: clamp(6.6rem, 24vw, 7.8rem);
 		}
 
-		.site-header__nav,
-		.site-header__cta {
+		.site-header__nav {
 			display: none;
+		}
+
+		.site-header__cta {
+			margin-inline-start: auto;
+			min-height: 2.45rem;
+			padding: 0 0.85rem;
+			border-radius: 0.8rem;
+			font-size: 1rem;
 		}
 
 		.site-header__mobile-menu {
 			display: block;
+			margin-inline-start: 0;
 		}
 	}
 

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -3,7 +3,6 @@ import type { ImageMetadata } from "astro";
 import homeData from "@/data/home.json";
 
 const { hero } = homeData;
-const { registration } = homeData;
 const heroIntro = hero.intro;
 const topics = heroIntro.topics;
 const heroWallImages = Object.entries(
@@ -48,8 +47,6 @@ const heroPhotoWallColumns = hero.photoWallColumns;
 			</h1>
 		</div>
 	</div>
-	<a class="hero-page__mobile-hero-cta" href="#registration-info">{registration.cta.label}</a>
-	<a class="hero-page__mobile-sticky-cta" data-hero-mobile-sticky-cta href="#registration-info" aria-hidden="true" tabindex="-1">{registration.cta.label}</a>
 </section>
 
 <script is:inline>
@@ -106,8 +103,6 @@ const heroPhotoWallColumns = hero.photoWallColumns;
 	const photoWallTracks = Array.from(document.querySelectorAll<HTMLElement>("[data-wall-track]"));
 	const heroSubtitle = document.querySelector<HTMLElement>("[data-hero-page-subtitle]");
 	const heroTitleLabel = document.querySelector<HTMLElement>("[data-hero-page-title-label]");
-	const heroPage = document.querySelector<HTMLElement>(".hero-page");
-	const mobileStickyCta = document.querySelector<HTMLElement>("[data-hero-mobile-sticky-cta]");
 	const question = intro?.querySelector<HTMLElement>("[data-hero-intro-question]");
 	const final = intro?.querySelector<HTMLElement>("[data-hero-intro-final]");
 	const topCurtain = intro?.querySelector<HTMLElement>("[data-hero-intro-curtain-top]");
@@ -152,28 +147,6 @@ const heroPhotoWallColumns = hero.photoWallColumns;
 	};
 
 	startPhotoWallAnimations();
-
-	if (heroPage && mobileStickyCta) {
-		document.body.append(mobileStickyCta);
-
-		const updateMobileStickyCta = () => {
-			const revealOffset = heroPage.offsetHeight - 1;
-			const isVisible = window.scrollY > revealOffset;
-
-			mobileStickyCta.classList.toggle("is-visible", isVisible);
-			mobileStickyCta.setAttribute("aria-hidden", String(!isVisible));
-
-			if (isVisible) {
-				mobileStickyCta.removeAttribute("tabindex");
-			} else {
-				mobileStickyCta.setAttribute("tabindex", "-1");
-			}
-		};
-
-		updateMobileStickyCta();
-		window.addEventListener("scroll", updateMobileStickyCta, { passive: true });
-		window.addEventListener("resize", updateMobileStickyCta);
-	}
 
 	const setActiveTopic = (activeIndex: number) => {
 		topics.forEach((topic, index) => {
@@ -561,77 +534,6 @@ const heroPhotoWallColumns = hero.photoWallColumns;
 		letter-spacing: 0;
 	}
 
-	.hero-page__mobile-hero-cta,
-	.hero-page__mobile-sticky-cta {
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		min-height: clamp(3rem, 3.7vw, 4rem);
-		padding: 0 clamp(1.15rem, 2vw, 2rem);
-		border: 0.16rem solid var(--color-foreground);
-		border-radius: clamp(0.8rem, 1.1vw, 1rem);
-		font-size: clamp(1.1rem, 1.4vw, 1.5rem);
-		font-weight: 800;
-		line-height: 1;
-		letter-spacing: 0;
-		text-decoration: none;
-		white-space: nowrap;
-		box-shadow: 0.22rem 0.22rem 0 0 var(--color-foreground);
-		transition:
-			background 160ms ease,
-			color 160ms ease,
-			transform 160ms ease,
-			box-shadow 160ms ease;
-	}
-
-	.hero-page__mobile-hero-cta:hover,
-	.hero-page__mobile-hero-cta:focus-visible,
-	.hero-page__mobile-sticky-cta:hover,
-	.hero-page__mobile-sticky-cta:focus-visible {
-		transform: translate(-0.08rem, -0.08rem);
-		box-shadow: 0.34rem 0.34rem 0 0 var(--color-foreground);
-	}
-
-	.hero-page__mobile-hero-cta:focus-visible,
-	.hero-page__mobile-sticky-cta:focus-visible {
-		outline: 0.18rem solid var(--color-primary-blue);
-		outline-offset: 0.22rem;
-	}
-
-	.hero-page__mobile-hero-cta,
-	.hero-page__mobile-sticky-cta {
-		color: var(--color-foreground);
-		background: var(--color-green);
-	}
-
-	.hero-page__mobile-hero-cta {
-		position: absolute;
-		inset-inline: 2rem;
-		inset-block-end: 6.65rem;
-		z-index: 4;
-		display: none;
-		min-height: 3.4rem;
-		font-size: 1.25rem;
-	}
-
-	.hero-page__mobile-sticky-cta {
-		position: fixed;
-		inset-inline: 1rem;
-		inset-block-end: max(0.9rem, env(safe-area-inset-bottom));
-		z-index: 1100;
-		display: none;
-		min-height: 3.4rem;
-		border-radius: 1rem;
-		font-size: 1.25rem;
-		opacity: 0;
-		pointer-events: none;
-	}
-
-	.hero-page__mobile-sticky-cta.is-visible {
-		opacity: 1;
-		pointer-events: auto;
-	}
-
 	:global(html.hero-intro-lock),
 	:global(html.hero-intro-lock body) {
 		overflow: hidden;
@@ -764,40 +666,13 @@ const heroPhotoWallColumns = hero.photoWallColumns;
 			padding-inline: 1rem;
 		}
 
-		.hero-page__mobile-hero-cta {
-			display: inline-flex;
-		}
-
-		.hero-page__mobile-sticky-cta {
-			display: inline-flex;
-		}
-
 		.hero-intro__stage {
 			width: calc(100vw - 1rem);
 		}
 	}
 
-	@media (max-width: 28rem) {
-		.hero-page__mobile-hero-cta {
-			inset-inline: 1rem;
-			inset-block-end: 6.2rem;
-		}
-	}
-
 	@media (prefers-reduced-motion: reduce) {
 		.hero-photo-wall__column-track {
-			transform: none;
-		}
-
-		.hero-page__mobile-hero-cta,
-		.hero-page__mobile-sticky-cta {
-			transition: none;
-		}
-
-		.hero-page__mobile-hero-cta:hover,
-		.hero-page__mobile-hero-cta:focus-visible,
-		.hero-page__mobile-sticky-cta:hover,
-		.hero-page__mobile-sticky-cta:focus-visible {
 			transform: none;
 		}
 	}

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -788,5 +788,17 @@ const heroPhotoWallColumns = hero.photoWallColumns;
 		.hero-photo-wall__column-track {
 			transform: none;
 		}
+
+		.hero-page__mobile-hero-cta,
+		.hero-page__mobile-sticky-cta {
+			transition: none;
+		}
+
+		.hero-page__mobile-hero-cta:hover,
+		.hero-page__mobile-hero-cta:focus-visible,
+		.hero-page__mobile-sticky-cta:hover,
+		.hero-page__mobile-sticky-cta:focus-visible {
+			transform: none;
+		}
 	}
 </style>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -3,6 +3,7 @@ import type { ImageMetadata } from "astro";
 import homeData from "@/data/home.json";
 
 const { hero } = homeData;
+const { registration } = homeData;
 const heroIntro = hero.intro;
 const topics = heroIntro.topics;
 const heroWallImages = Object.entries(
@@ -40,11 +41,15 @@ const heroPhotoWallColumns = hero.photoWallColumns;
 		}
 	</div>
 	<div class="hero-page__content">
-		<p class="hero-page__subtitle" data-hero-page-subtitle>{hero.subtitle}</p>
-		<h1 id="hero-page-title" class="hero-page__title" data-hero-page-title>
-			<span data-hero-page-title-label>{hero.title}</span>
-		</h1>
+		<div class="hero-page__headline">
+			<p class="hero-page__subtitle" data-hero-page-subtitle>{hero.subtitle}</p>
+			<h1 id="hero-page-title" class="hero-page__title" data-hero-page-title>
+				<span data-hero-page-title-label>{hero.title}</span>
+			</h1>
+		</div>
 	</div>
+	<a class="hero-page__mobile-hero-cta" href="#registration-info">{registration.cta.label}</a>
+	<a class="hero-page__mobile-sticky-cta" data-hero-mobile-sticky-cta href="#registration-info" aria-hidden="true" tabindex="-1">{registration.cta.label}</a>
 </section>
 
 <script is:inline>
@@ -101,6 +106,8 @@ const heroPhotoWallColumns = hero.photoWallColumns;
 	const photoWallTracks = Array.from(document.querySelectorAll<HTMLElement>("[data-wall-track]"));
 	const heroSubtitle = document.querySelector<HTMLElement>("[data-hero-page-subtitle]");
 	const heroTitleLabel = document.querySelector<HTMLElement>("[data-hero-page-title-label]");
+	const heroPage = document.querySelector<HTMLElement>(".hero-page");
+	const mobileStickyCta = document.querySelector<HTMLElement>("[data-hero-mobile-sticky-cta]");
 	const question = intro?.querySelector<HTMLElement>("[data-hero-intro-question]");
 	const final = intro?.querySelector<HTMLElement>("[data-hero-intro-final]");
 	const topCurtain = intro?.querySelector<HTMLElement>("[data-hero-intro-curtain-top]");
@@ -145,6 +152,28 @@ const heroPhotoWallColumns = hero.photoWallColumns;
 	};
 
 	startPhotoWallAnimations();
+
+	if (heroPage && mobileStickyCta) {
+		document.body.append(mobileStickyCta);
+
+		const updateMobileStickyCta = () => {
+			const revealOffset = heroPage.offsetHeight - 1;
+			const isVisible = window.scrollY > revealOffset;
+
+			mobileStickyCta.classList.toggle("is-visible", isVisible);
+			mobileStickyCta.setAttribute("aria-hidden", String(!isVisible));
+
+			if (isVisible) {
+				mobileStickyCta.removeAttribute("tabindex");
+			} else {
+				mobileStickyCta.setAttribute("tabindex", "-1");
+			}
+		};
+
+		updateMobileStickyCta();
+		window.addEventListener("scroll", updateMobileStickyCta, { passive: true });
+		window.addEventListener("resize", updateMobileStickyCta);
+	}
 
 	const setActiveTopic = (activeIndex: number) => {
 		topics.forEach((topic, index) => {
@@ -502,6 +531,12 @@ const heroPhotoWallColumns = hero.photoWallColumns;
 		background: var(--color-background);
 	}
 
+	.hero-page__headline {
+		display: grid;
+		min-width: 0;
+		gap: clamp(0.35rem, 1.2vw, 0.9rem);
+	}
+
 	.hero-page__subtitle {
 		margin: 0;
 		font-size: clamp(1.125rem, 2.8vw, 2.25rem);
@@ -524,6 +559,77 @@ const heroPhotoWallColumns = hero.photoWallColumns;
 		font-weight: 800;
 		line-height: 0.9;
 		letter-spacing: 0;
+	}
+
+	.hero-page__mobile-hero-cta,
+	.hero-page__mobile-sticky-cta {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		min-height: clamp(3rem, 3.7vw, 4rem);
+		padding: 0 clamp(1.15rem, 2vw, 2rem);
+		border: 0.16rem solid var(--color-foreground);
+		border-radius: clamp(0.8rem, 1.1vw, 1rem);
+		font-size: clamp(1.1rem, 1.4vw, 1.5rem);
+		font-weight: 800;
+		line-height: 1;
+		letter-spacing: 0;
+		text-decoration: none;
+		white-space: nowrap;
+		box-shadow: 0.22rem 0.22rem 0 0 var(--color-foreground);
+		transition:
+			background 160ms ease,
+			color 160ms ease,
+			transform 160ms ease,
+			box-shadow 160ms ease;
+	}
+
+	.hero-page__mobile-hero-cta:hover,
+	.hero-page__mobile-hero-cta:focus-visible,
+	.hero-page__mobile-sticky-cta:hover,
+	.hero-page__mobile-sticky-cta:focus-visible {
+		transform: translate(-0.08rem, -0.08rem);
+		box-shadow: 0.34rem 0.34rem 0 0 var(--color-foreground);
+	}
+
+	.hero-page__mobile-hero-cta:focus-visible,
+	.hero-page__mobile-sticky-cta:focus-visible {
+		outline: 0.18rem solid var(--color-primary-blue);
+		outline-offset: 0.22rem;
+	}
+
+	.hero-page__mobile-hero-cta,
+	.hero-page__mobile-sticky-cta {
+		color: var(--color-foreground);
+		background: var(--color-green);
+	}
+
+	.hero-page__mobile-hero-cta {
+		position: absolute;
+		inset-inline: 2rem;
+		inset-block-end: 6.65rem;
+		z-index: 4;
+		display: none;
+		min-height: 3.4rem;
+		font-size: 1.25rem;
+	}
+
+	.hero-page__mobile-sticky-cta {
+		position: fixed;
+		inset-inline: 1rem;
+		inset-block-end: max(0.9rem, env(safe-area-inset-bottom));
+		z-index: 1100;
+		display: none;
+		min-height: 3.4rem;
+		border-radius: 1rem;
+		font-size: 1.25rem;
+		opacity: 0;
+		pointer-events: none;
+	}
+
+	.hero-page__mobile-sticky-cta.is-visible {
+		opacity: 1;
+		pointer-events: auto;
 	}
 
 	:global(html.hero-intro-lock),
@@ -658,8 +764,23 @@ const heroPhotoWallColumns = hero.photoWallColumns;
 			padding-inline: 1rem;
 		}
 
+		.hero-page__mobile-hero-cta {
+			display: inline-flex;
+		}
+
+		.hero-page__mobile-sticky-cta {
+			display: inline-flex;
+		}
+
 		.hero-intro__stage {
 			width: calc(100vw - 1rem);
+		}
+	}
+
+	@media (max-width: 28rem) {
+		.hero-page__mobile-hero-cta {
+			inset-inline: 1rem;
+			inset-block-end: 6.2rem;
 		}
 	}
 


### PR DESCRIPTION
## Summary
- 在 Hero 區塊新增手機版報名 CTA 按鈕，scroll 過 hero 後顯示固定於底部的 sticky CTA
- 將 hero subtitle 與 title 包進 `.hero-page__headline` 容器，避免與新 CTA 排版衝突
- CTA 透過錨點連結 `#registration-info` 導向報名區段
- 補上 `prefers-reduced-motion` 規則，讓兩個新 CTA 在使用者偏好減少動態時停用 transition 與 hover transform

## Test plan
- [x] 在桌面版確認 hero CTA 與 sticky CTA 不顯示，原版面無變動
- [x] 在手機版確認 hero 內 CTA 顯示，且點擊後可滾動至 `#registration-info`
- [x] 在手機版捲動超過 hero 後確認 sticky CTA 出現於底部，捲回頂部後消失
- [x] 確認 sticky CTA 對 `prefers-reduced-motion`、`safe-area-inset` 等環境表現正常

### `prefers-reduced-motion: reduce`
以 Playwright 模擬 iPhone 13 + reduced-motion 偏好驗證：

| 項目 | 結果 |
| --- | --- |
| sticky CTA 顯示／隱藏邏輯 | ✅ scroll 過 hero 後 `.is-visible` 套用、opacity 1、可點擊 |
| `transition-duration` | ✅ `0s`（修正後） |
| hover/focus transform | ✅ `none`（修正後） |

> 修正前 `transition` 仍為 `0.16s`、hover transform 仍會觸發。已於 commit [`e1232a5`](https://github.com/sitcon-tw/camp2026/commit/e1232a5) 補上 `@media (prefers-reduced-motion: reduce)` 區塊停用。

### `safe-area-inset-bottom`
使用 Playwright 注入模擬 `env(safe-area-inset-bottom)` 值驗證 `inset-block-end: max(0.9rem, env(safe-area-inset-bottom))`：

| 模擬 safe-area | 計算後 `bottom` |
| --- | --- |
| 0（無） | `14.4px`（= `0.9rem`） |
| `34px`（iPhone 有 home indicator 的典型值） | `34px` |

`max()` 邏輯正確 — 沒有 safe-area 時用最小邊距，有 safe-area 時自動避開 home indicator。

## Screenshots

**桌面版 hero — 不顯示 CTA（版面無變動）**

<img width="640" alt="desktop hero" src="https://github.com/user-attachments/assets/ced9fc5c-fa92-4cf8-b8e4-8b1bec926261" />

**手機版**

| 內嵌 CTA | 捲動後 sticky CTA |
| :---: | :---: |
| <img width="260" alt="mobile hero cta" src="https://github.com/user-attachments/assets/2bbd4224-adad-44f6-9f1b-db59924e4268" /> | <img width="260" alt="mobile sticky cta" src="https://github.com/user-attachments/assets/f2f42807-db2f-40d7-91b9-4308fa5ef451" /> |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized hero section headline layout structure to improve spacing and visual flow
  * Simplified mobile navigation menu composition
  * Refined responsive display behavior for navigation and call-to-action elements

* **Style**
  * Enhanced focus and hover state styling for improved navigation interaction feedback
  * Optimized visual presentation of navigation elements across screen sizes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->