### PR TITLE
fix: offset anchor scroll for fixed header

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -32,6 +32,7 @@
 		background-color: var(--color-background);
 		text-size-adjust: 100%;
 		-webkit-text-size-adjust: 100%;
+		scroll-padding-top: clamp(5rem, 7vw, 7.5rem);
 	}
 
 	body {


### PR DESCRIPTION
## Summary
- 點擊「立即報名」（或任何 in-page hash 連結）後，目標 section 的標題會被 fixed nav bar 蓋住。
- 在 `html` 設 `scroll-padding-top: clamp(5rem, 7vw, 7.5rem)`，讓瀏覽器原生 anchor scroll 自動避開 header；同時涵蓋 `#master-class`、`#team` 等其它 anchor。
- clamp 範圍對應 header 在不同 breakpoint 的高度（≈4.1–6.7rem）並留有呼吸空間。

## Test plan
- [x] 桌面寬度點擊 hero「立即報名」按鈕，確認「報名資訊」標題完整顯示在 nav bar 下方
- [x] 手機寬度點擊 hero 與 sticky CTA，同樣確認標題未被遮住
- [x] 直接以 `#registration-info` 開啟頁面（重新整理 / 分享連結），標題不被遮
- [x] 確認 `#master-class`、`#team` 等其它 anchor 也有適當 offset

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved scroll anchor positioning for better visual alignment when navigating to page sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->