### PR TITLE
fix(seo): scope structured data per page

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -20,7 +20,6 @@ const { document: pageDocument } = layoutData;
 
 const siteURL = Astro.site ?? new URL("https://sitcon.camp");
 const canonicalURL = new URL(Astro.url.pathname, siteURL);
-const homeURL = new URL("/2026/", siteURL);
 
 const seoData = {
 	title: title ?? pageDocument.defaultTitle,
@@ -31,39 +30,6 @@ const seoData = {
 	ogType: type,
 	robots: noindex ? "noindex, nofollow" : "index, follow, max-image-preview:large"
 };
-
-const publisher = {
-	"@type": "Organization",
-	name: layoutData.organization.name,
-	url: layoutData.organization.url
-};
-
-const structuredData = [
-	{
-		...layoutData.eventLD,
-		image: [seoData.ogImage],
-		organizer: {
-			...layoutData.eventLD.organizer,
-			sameAs: layoutData.organization.sameAs
-		},
-		url: homeURL.href
-	},
-	{
-		"@context": "https://schema.org",
-		"@type": "WebSite",
-		name: pageDocument.brandName,
-		url: homeURL.href,
-		description: pageDocument.description,
-		inLanguage: pageDocument.lang,
-		publisher
-	},
-	{
-		"@context": "https://schema.org",
-		...publisher,
-		logo: new URL("/2026/favicon.svg", siteURL).href,
-		sameAs: layoutData.organization.sameAs
-	}
-];
 ---
 
 <!doctype html>
@@ -123,8 +89,7 @@ const structuredData = [
 		<meta name="twitter:image" content={seoData.ogImage} />
 		<meta name="twitter:image:alt" content={seoData.ogImageAlt} />
 
-		<!-- JSON-LD: Event / Site / Organization -->
-		{!noindex && <script type="application/ld+json" set:html={JSON.stringify(structuredData)} is:inline />}
+		<!-- JSON-LD: page-specific structured data -->
 		{!noindex && additionalStructuredData && <script type="application/ld+json" set:html={JSON.stringify(additionalStructuredData)} is:inline />}
 		<ClientRouter />
 	</head>

--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -4,8 +4,32 @@ import Team from "@/components/Team.astro";
 import OrganizerBrands from "@/components/OrganizerBrands.astro";
 import Layout from "@/layouts/Layout.astro";
 import pageData from "@/data/about.json";
+import layoutData from "@/data/layout.json";
 
 const { pageMeta } = pageData;
+const siteURL = Astro.site ?? new URL("https://sitcon.camp");
+const homeURL = new URL("/2026/", siteURL);
+const aboutURL = new URL("/2026/about/", siteURL);
+
+const aboutPageSchema = {
+	"@context": "https://schema.org",
+	"@type": "AboutPage",
+	name: pageMeta.title,
+	description: pageMeta.description,
+	url: aboutURL.href,
+	inLanguage: layoutData.document.lang,
+	isPartOf: {
+		"@type": "WebSite",
+		name: layoutData.document.brandName,
+		url: homeURL.href
+	},
+	mainEntity: {
+		"@type": "Organization",
+		name: layoutData.organization.name,
+		url: layoutData.organization.url,
+		sameAs: layoutData.organization.sameAs
+	}
+};
 
 const breadcrumbSchema = {
 	"@context": "https://schema.org",
@@ -15,19 +39,21 @@ const breadcrumbSchema = {
 			"@type": "ListItem",
 			position: 1,
 			name: "SITCON 夏令營 2026",
-			item: "https://sitcon.camp/2026/"
+			item: homeURL.href
 		},
 		{
 			"@type": "ListItem",
 			position: 2,
 			name: "關於我們",
-			item: "https://sitcon.camp/2026/about/"
+			item: aboutURL.href
 		}
 	]
 };
+
+const structuredData = [aboutPageSchema, breadcrumbSchema];
 ---
 
-<Layout title={pageMeta.title} description={pageMeta.description} additionalStructuredData={breadcrumbSchema}>
+<Layout title={pageMeta.title} description={pageMeta.description} additionalStructuredData={structuredData}>
 	<EventsHeld />
 	<Team />
 	<OrganizerBrands />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,7 +10,44 @@ import RegistrationInfo from "@/components/RegistrationInfo.astro";
 import FAQ from "@/components/FAQ.astro";
 import OrganizersBrands from "@/components/OrganizerBrands.astro";
 import homeData from "@/data/home.json";
+import layoutData from "@/data/layout.json";
 import { markdownToPlainText } from "@/utils/markdown";
+
+const siteURL = Astro.site ?? new URL("https://sitcon.camp");
+const homeURL = new URL("/2026/", siteURL);
+const ogImage = new URL("/2026/og.jpg", siteURL);
+const publisher = {
+	"@type": "Organization",
+	name: layoutData.organization.name,
+	url: layoutData.organization.url
+};
+
+const eventSchema = {
+	...layoutData.eventLD,
+	image: [ogImage.href],
+	organizer: {
+		...layoutData.eventLD.organizer,
+		sameAs: layoutData.organization.sameAs
+	},
+	url: homeURL.href
+};
+
+const websiteSchema = {
+	"@context": "https://schema.org",
+	"@type": "WebSite",
+	name: layoutData.document.brandName,
+	url: homeURL.href,
+	description: layoutData.document.description,
+	inLanguage: layoutData.document.lang,
+	publisher
+};
+
+const organizationSchema = {
+	"@context": "https://schema.org",
+	...publisher,
+	logo: new URL("/2026/favicon.svg", siteURL).href,
+	sameAs: layoutData.organization.sameAs
+};
 
 const faqSchema = {
 	"@context": "https://schema.org",
@@ -24,9 +61,11 @@ const faqSchema = {
 		}
 	}))
 };
+
+const structuredData = [eventSchema, websiteSchema, organizationSchema, faqSchema];
 ---
 
-<Layout additionalStructuredData={faqSchema}>
+<Layout additionalStructuredData={structuredData}>
 	<Hero />
 	<BrandMarquee />
 	<MasterClass />


### PR DESCRIPTION
## 背景

目前 `Layout.astro` 會在所有可索引頁面輸出同一組 `EducationEvent`、`WebSite`、`Organization` JSON-LD。這讓 `/2026/about/` 這類次頁也帶著首頁活動 schema，搜尋引擎會看到與頁面主體不夠貼合的結構化資料。

結構化資料應該描述當前頁面的主要可見內容。首頁放活動、網站、組織與 FAQ schema 合理；about 頁則更適合用 `AboutPage` 搭配 `BreadcrumbList`，並以 `mainEntity` 關聯到 SITCON 組織，而不是重複輸出活動 schema。

## 修改內容

- 移除 `Layout.astro` 內建的全站共用 JSON-LD，改成只輸出頁面明確傳入的 `additionalStructuredData`。
- 首頁改為自行組出 `EducationEvent`、`WebSite`、`Organization`、`FAQPage`。
- About 頁改為自行組出 `AboutPage` 與 `BreadcrumbList`。
- FAQ schema 維持從 `homeData.faq.items` 產生，答案仍透過 `markdownToPlainText()` 從同一份 Markdown 內容轉出，避免 schema 文字和畫面內容分離維護。

## 驗證

- `pnpm prettier:check`
- `pnpm lint`
- `pnpm build`
- 抽查 build 後的 JSON-LD 類型：
  - `dist/index.html`: `EducationEvent, WebSite, Organization, FAQPage`
  - `dist/about/index.html`: `AboutPage, BreadcrumbList`

補充：本機 sandbox 內第一次 `pnpm build` 因 Astro font server 需要 listen 被擋，改用核准的 escalated 執行後通過。Push 時遠端 hook 也重新跑過 `pnpm lint` 與 `pnpm prettier:check` 並通過。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated structured data handling and canonical URL construction sitewide for more consistent SEO output.

* **New Features**
  * Added JSON-LD structured data to the homepage and About page (FAQ, event, organization, breadcrumb, etc.) to improve search engine presentation and rich result eligibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->