### PR TITLE
fix(pwa): remove install metadata

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,31 +10,20 @@ import favicons from "astro-favicons";
 
 const base = "/2026";
 const basePath = base.replace(/^\/+|\/+$/g, "");
-const pwaAssetNames = new Set([
-	"android-chrome-192x192.png",
-	"android-chrome-512x512.png",
+const faviconAssetNames = new Set([
 	"apple-touch-icon-precomposed.png",
 	"apple-touch-icon.png",
-	"browserconfig.xml",
 	"favicon-16x16.png",
 	"favicon-32x32.png",
 	"favicon-48x48.png",
 	"favicon.ico",
 	"favicon.svg",
-	"manifest.webmanifest",
-	"mstile-144x144.png",
-	"mstile-150x150.png",
-	"mstile-310x150.png",
-	"mstile-310x310.png",
-	"mstile-70x70.png",
-	"safari-pinned-tab.svg",
-	"yandex-browser-50x50.png",
-	"yandex-browser-manifest.json"
+	"safari-pinned-tab.svg"
 ]);
 
-function emitPwaAssetsAtArtifactRoot() {
+function emitFaviconAssetsAtArtifactRoot() {
 	return {
-		name: "camp:pwa-assets-at-artifact-root",
+		name: "camp:favicon-assets-at-artifact-root",
 		enforce: /** @type {"post"} */ ("post"),
 		/**
 		 * @param {unknown} _
@@ -42,14 +31,14 @@ function emitPwaAssetsAtArtifactRoot() {
 		 */
 		generateBundle(_, bundle) {
 			for (const [fileName, asset] of Object.entries(bundle)) {
-				const pwaAssetName = fileName.startsWith(`${basePath}/`) ? fileName.slice(basePath.length + 1) : "";
+				const faviconAssetName = fileName.startsWith(`${basePath}/`) ? fileName.slice(basePath.length + 1) : "";
 
-				if (!pwaAssetNames.has(pwaAssetName)) {
+				if (!faviconAssetNames.has(faviconAssetName)) {
 					continue;
 				}
 
-				asset.fileName = pwaAssetName;
-				bundle[pwaAssetName] = asset;
+				asset.fileName = faviconAssetName;
+				bundle[faviconAssetName] = asset;
 				delete bundle[fileName];
 			}
 		}
@@ -127,7 +116,7 @@ export default defineConfig({
 			Icons({
 				compiler: "astro"
 			}),
-			emitPwaAssetsAtArtifactRoot()
+			emitFaviconAssetsAtArtifactRoot()
 		]
 	},
 
@@ -136,16 +125,18 @@ export default defineConfig({
 		favicons({
 			name: "SITCON Camp 2026",
 			short_name: "SITCON Camp",
-			manifest: {
-				start_url: `${base}/`,
-				display: "standalone",
-				orientation: "any",
-				display_override: ["window-controls-overlay", "minimal-ui"]
+			icons: {
+				android: false,
+				appleIcon: ["apple-touch-icon.png", "apple-touch-icon-precomposed.png", "safari-pinned-tab.svg"],
+				appleStartup: false,
+				favicons: true,
+				windows: false,
+				yandex: false
 			},
 			output: {
 				images: true,
-				files: true,
-				html: true,
+				files: false,
+				html: false,
 				assetsPrefix: base
 			}
 		})

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -67,6 +67,13 @@ const seoData = {
 		<link rel="canonical" href={seoData.canonicalURL} />
 		<link rel="sitemap" href="/2026/sitemap-index.xml" />
 		<meta name="theme-color" content="#80d34b" />
+		<link rel="apple-touch-icon" sizes="180x180" href="/2026/apple-touch-icon.png" />
+		<link rel="icon" type="image/x-icon" href="/2026/favicon.ico" />
+		<link rel="icon" type="image/png" sizes="16x16" href="/2026/favicon-16x16.png" />
+		<link rel="icon" type="image/png" sizes="32x32" href="/2026/favicon-32x32.png" />
+		<link rel="icon" type="image/png" sizes="48x48" href="/2026/favicon-48x48.png" />
+		<link rel="icon" type="image/svg+xml" href="/2026/favicon.svg" />
+		<link rel="mask-icon" href="/2026/safari-pinned-tab.svg" color="#80d34b" />
 
 		<!-- SEO: Open Graph -->
 		<meta property="og:type" content={seoData.ogType} />


### PR DESCRIPTION
## Summary

- Stop generating web app manifest and install-related metadata for the camp site.
- Keep the normal favicon, Apple touch icon, and Safari pinned tab icon links for browser/tab presentation.
- Keep generated favicon assets at the deploy artifact root so `/2026/...` URLs continue to work in the aggregate camp deployment.

## Why

This is an event website, not an installable app. Browser install prompts can obscure the navbar and confuse visitors who only need the event information.

## Validation

- `pnpm build`
- `pnpm lint`
- `pnpm prettier:check`
- Confirmed build output contains only favicon/touch/pinned icon assets, with no manifest or install metadata tags in generated HTML.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Modernized favicon and app icon support system with comprehensive configuration for multiple sizes, formats, and platform-specific variants including Apple touch icons, Safari pinned tabs with theme colors, SVG icons, and optimized favicon assets for enhanced compatibility across all major browsers and devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->