### PR TITLE
fix(team): remove max-width from group description in Team.astro

### DIFF
--- a/src/components/Team.astro
+++ b/src/components/Team.astro
@@ -1,4 +1,4 @@
-﻿---
+---
 import { Image } from "astro:assets";
 import type { ImageMetadata } from "astro";
 import LucideX from "~icons/lucide/x";
@@ -174,7 +174,7 @@ const avatarImages = import.meta.glob<{ default: ImageMetadata }>("../assets/tea
 			teamGroups.map(group => (
 				<section class="my-4 mt-12 lg:mt-16">
 					<h2 class="text-4xl font-bold text-black">{group.name}</h2>
-					{group.description && <p class="text-foreground/70 mt-3 max-w-3xl text-lg leading-[1.7] font-bold">{group.description}</p>}
+					{group.description && <p class="text-foreground/70 mt-3 text-lg leading-[1.7] font-bold">{group.description}</p>}
 
 					<div class="my-4 grid h-fit w-full grid-cols-[repeat(auto-fill,minmax(9.375rem,1fr))] justify-items-center gap-[clamp(1rem,20vw,2rem)]">
 						{group.members.map(data => (


### PR DESCRIPTION
## 變更摘要

移除 Team 頁面 group description 的 `max-width`，防止文字在窄版時過早換行。

## 變更類型

- [x] 頁面或元件更新
- [ ] 內容或資料更新 (`src/data`)
- [ ] 圖片、字型或靜態資源更新 (`src/assets` 或 `public`)
- [ ] 樣式、layout 或動畫更新
- [ ] SEO、metadata、sitemap 或 manifest 更新
- [ ] Build、CI、deploy 或 tooling 更新

## 關聯 Issue

<!-- 連結相關 issue，例如：Closes #123 -->

Closes #120 

## 驗證

- [x] `pnpm build`
- [x] `pnpm lint`
- [x] `pnpm prettier:check`
- [x] 已使用 `pnpm run dev` 檢查相關頁面
- [x] 若有 UI 變更，已檢查 RWD 顯示
- [ ] 若有公開內容更新，已確認內容正確且可公開

## Reviewer 注意事項

變更極小（2 lines），僅移除 `max-width` 限制。沒有更改其他元件。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed width constraints from team description paragraphs for improved display flexibility.

* **Bug Fixes**
  * Corrected file encoding issue.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sitcon-tw/camp2026/pull/121)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->