### PR TITLE
feat: add button to nudge users towards schedule

### DIFF
--- a/src/components/MasterClass.astro
+++ b/src/components/MasterClass.astro
@@ -1,6 +1,7 @@
 ---
 import type { ImageMetadata } from "astro";
 import { Image } from "astro:assets";
+import IcRoundChevronRight from "~icons/ic/round-chevron-right";
 import homeData from "@/data/home.json";
 
 const { masterClassSection, masterClasses } = homeData;
@@ -239,6 +240,10 @@ const getMasterImage = (masterClass: MasterClassItem) => {
 						))
 					}
 				</div>
+				<a class="master-carousel__schedule-link" href={masterClassSection.scheduleLink.href}>
+					<span class="master-carousel__schedule-link-label">{masterClassSection.scheduleLink.label}</span>
+					<IcRoundChevronRight class="master-carousel__schedule-link-icon" aria-hidden="true" />
+				</a>
 			</div>
 		</div>
 	</div>
@@ -964,10 +969,12 @@ const getMasterImage = (masterClass: MasterClassItem) => {
 		z-index: 20;
 		display: flex;
 		min-width: 0;
+		width: var(--carousel-slide-width);
 		max-width: 100%;
+		margin-inline: auto;
 		align-items: center;
-		justify-content: center;
-		padding-inline: var(--site-content-gutter);
+		justify-content: space-between;
+		gap: clamp(0.75rem, 1.6vw, 1.25rem);
 	}
 
 	.master-carousel__tabs {
@@ -1026,6 +1033,41 @@ const getMasterImage = (masterClass: MasterClassItem) => {
 		color: var(--color-background);
 		cursor: default;
 		pointer-events: none;
+	}
+
+	.master-carousel__schedule-link {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.32rem;
+		padding: 0.55rem 0.85rem 0.55rem 1.1rem;
+		border: 0.14rem solid var(--color-foreground);
+		border-radius: 999rem;
+		background: var(--color-background);
+		box-shadow: 0.24rem 0.24rem 0 var(--color-foreground);
+		color: var(--color-foreground);
+		font-size: clamp(0.9rem, 1.1vw, 1.02rem);
+		font-weight: 800;
+		line-height: 1;
+		letter-spacing: 0;
+		text-decoration: none;
+		white-space: nowrap;
+		transition:
+			transform 180ms ease,
+			box-shadow 180ms ease,
+			background-color 180ms ease,
+			color 180ms ease;
+	}
+
+	.master-carousel__schedule-link:hover,
+	.master-carousel__schedule-link:focus-visible {
+		background: var(--color-primary-blue);
+		color: var(--color-background);
+		transform: translate3d(-0.08rem, -0.08rem, 0);
+		box-shadow: 0.32rem 0.32rem 0 var(--color-foreground);
+	}
+
+	.master-carousel__schedule-link-icon {
+		font-size: 1.1em;
 	}
 
 	@media (max-width: 72rem) {
@@ -1247,7 +1289,9 @@ const getMasterImage = (masterClass: MasterClassItem) => {
 		}
 
 		.master-carousel__controls {
+			flex-wrap: wrap;
 			justify-content: center;
+			gap: 0.5rem;
 			overflow: visible;
 			padding-block-end: 0.35rem;
 			scrollbar-width: none;
@@ -1255,6 +1299,12 @@ const getMasterImage = (masterClass: MasterClassItem) => {
 
 		.master-carousel__controls::-webkit-scrollbar {
 			display: none;
+		}
+
+		.master-carousel__schedule-link {
+			padding: 0.42rem 0.7rem 0.42rem 0.85rem;
+			font-size: 0.82rem;
+			box-shadow: 0.2rem 0.2rem 0 var(--color-foreground);
 		}
 
 		.master-carousel__tabs {

--- a/src/data/home.json
+++ b/src/data/home.json
@@ -213,7 +213,11 @@
 		"eyebrow": "主線課程",
 		"title": "三大實戰主題，由強者講師帶路",
 		"lead": "由具備國際大獎經歷的導師親自操刀，將業界真實的技術決策，濃縮成無可取代的實戰武器",
-		"deckAriaLabel": "Master Class 課程卡片"
+		"deckAriaLabel": "Master Class 課程卡片",
+		"scheduleLink": {
+			"label": "查看完整課表",
+			"href": "/2026/schedule/"
+		}
 	},
 	"masterClasses": [
 		{


### PR DESCRIPTION
## 變更摘要

在 2026 官網下方「主線課程」中新增按鈕讓使用者可以快速點到課表

## 變更類型

- [X] 頁面或元件更新
- [X] 內容或資料更新 (`src/data`)
- [ ] 圖片、字型或靜態資源更新 (`src/assets` 或 `public`)
- [X] 樣式、layout 或動畫更新
- [ ] SEO、metadata、sitemap 或 manifest 更新
- [ ] Build、CI、deploy 或 tooling 更新

## 關聯 Issue

無

## 驗證

- [X] `pnpm build`
- [X] `pnpm lint`
- [X] `pnpm prettier:check`
- [X] 已使用 `pnpm run dev` 檢查相關頁面
- [X] 若有 UI 變更，已檢查 RWD 顯示
- [X] 若有公開內容更新，已確認內容正確且可公開

## 截圖或錄影

## Reviewer 注意事項


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a schedule link directly in the master carousel, providing quick access to the complete course schedule.
* **Style**
  * Improved carousel controls layout with better alignment and spacing. Enhanced styling for the new schedule link, including refined hover and focus states for optimal accessibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sitcon-tw/camp2026/pull/129)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->