### PR TITLE
fix: fix archive not apply link-base class

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -118,7 +118,7 @@ type FooterIcon = keyof typeof iconMap;
 	}
 
 	.link-base {
-		@apply font-medium text-white transition-colors;
+		@apply text-white transition-colors;
 	}
 
 	.link-hover-green:hover {

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -39,7 +39,7 @@ type FooterIcon = keyof typeof iconMap;
 							<div class="mb-5">
 								{section.label && <p class="text-muted mb-1 text-sm font-bold">{section.label}</p>}
 								{section.links.map(link => (
-									<a href={link.href} class:list={["link-base", `link-hover-${section.variant}`]}>
+									<a href={link.href} class:list={["link-base font-bold", `link-hover-${section.variant}`]}>
 										{link.label}
 									</a>
 								))}

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -61,7 +61,7 @@ type FooterIcon = keyof typeof iconMap;
 						{section.type === "archive" && (
 							<div class="grid w-max grid-cols-3 gap-x-6 gap-y-4 text-sm font-bold text-white">
 								{section.links.map(link => (
-									<a href={link.href} class:list={[`link-hover-${section.variant}`]}>
+									<a href={link.href} class:list={["link-base", `link-hover-${section.variant}`]}>
 										{link.label}
 									</a>
 								))}


### PR DESCRIPTION
## 變更摘要

修正頁腳中，歷年官網區塊的連結文字未套用顏色漸變時長，各連結文字 weight 不同的問題。

<!-- 簡短描述這個 PR 改了什麼，以及為什麼需要這次變更。 -->

## 變更類型

- [x] 頁面或元件更新
- [ ] 內容或資料更新 (`src/data`)
- [ ] 圖片、字型或靜態資源更新 (`src/assets` 或 `public`)
- [x] 樣式、layout 或動畫更新
- [ ] SEO、metadata、sitemap 或 manifest 更新
- [ ] Build、CI、deploy 或 tooling 更新

## 關聯 Issue

<!-- 連結相關 issue，例如：Closes #123 -->

## 驗證

- [x] `pnpm build`
- [x] `pnpm lint`
- [x] `pnpm prettier:check`
- [x] 已使用 `pnpm run dev` 檢查相關頁面
- [x] 若有 UI 變更，已檢查 RWD 顯示
- [x] 若有公開內容更新，已確認內容正確且可公開

## 截圖或錄影

<!-- 若有視覺變更，請附上 before/after 截圖或錄影。沒有則可留空。 -->

### Before

連結文字 weight 不統一，歷年官網文字未套用 hover 轉換時的顏色漸變。

<img width="1920" height="1080" alt="圖片" src="https://github.com/user-attachments/assets/4e9b938e-67ab-44a4-bafc-115555f93838" />

### After

統一連結文字 weight 為 bold (700)，為歷年官網文字套用 `link-base` 的 class。

<img width="1920" height="1080" alt="圖片" src="https://github.com/user-attachments/assets/ea6138bc-1a1b-470c-b5e7-31a288462706" />


## Reviewer 注意事項

<!-- 補充高風險區塊、後續事項、部署注意事項，或希望 reviewer 特別看的地方。 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* Updated footer link styling for improved visual consistency in contact and archive sections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sitcon-tw/camp2026/pull/131?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->