### PR TITLE
fix(header): fix header highlight not apply after page transition

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -246,12 +246,8 @@ const { header } = layoutData;
 
 	const normalizePath = (path: string) => path.replace(/\/$/, "") || "/";
 
-	const updateHeaderState = () => {
+	const updateActiveNav = () => {
 		const current = normalizePath(location.pathname);
-
-		if (siteHeader) {
-			siteHeader.classList.toggle("is-visible", current !== "/2026");
-		}
 
 		document.querySelectorAll<HTMLAnchorElement>("[data-nav-link]").forEach(link => {
 			const href = link.dataset.href;
@@ -260,11 +256,9 @@ const { header } = layoutData;
 				return;
 			}
 
-			const isAnchor = href.includes("#");
-
 			let active = false;
 
-			if (!isAnchor) {
+			if (!href.includes("#")) {
 				const nav = normalizePath(new URL(href, location.origin).pathname);
 
 				active = nav === "/2026" ? current === nav : current === nav || current.startsWith(`${nav}/`);
@@ -282,9 +276,9 @@ const { header } = layoutData;
 		});
 	};
 
-	updateHeaderState();
+	updateActiveNav();
 
-	document.addEventListener("astro:page-load", updateHeaderState);
+	document.addEventListener("astro:page-load", updateActiveNav);
 </script>
 
 <style>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -5,28 +5,9 @@ import SitconCampLogo from "@/assets/brand/sitcon-camp-logo.svg";
 import layoutData from "@/data/layout.json";
 
 const { header } = layoutData;
-const currentPath = Astro.url.pathname.replace(/\/$/, "") || "/";
-const getNavPath = (href: string) => new URL(href, Astro.site ?? "https://sitcon.camp").pathname.replace(/\/$/, "") || "/";
-const isNavItemActive = (href: string) => {
-	if (href.includes("#")) {
-		return false;
-	}
-
-	const navPath = getNavPath(href);
-
-	if (navPath === "/2026/schedule") {
-		return false;
-	}
-
-	if (navPath === "/2026") {
-		return currentPath === navPath;
-	}
-
-	return currentPath === navPath || currentPath.startsWith(`${navPath}/`);
-};
 ---
 
-<header class:list={["site-header", { "is-visible": currentPath !== "/2026" }]} data-site-header data-astro-transition-persist="site-header" aria-label={header.ariaLabel}>
+<header class="site-header" data-site-header data-astro-transition-persist="site-header" aria-label={header.ariaLabel}>
 	<a class="site-header__brand" href={header.brand.href} aria-label={header.brand.ariaLabel}>
 		<img class="site-header__logo" src={SitconCampLogo.src} width={SitconCampLogo.width} height={SitconCampLogo.height} alt={header.brand.logoAlt} />
 	</a>
@@ -34,14 +15,16 @@ const isNavItemActive = (href: string) => {
 	<nav class="site-header__nav" aria-label={header.navAriaLabel}>
 		{
 			header.navItems.map(item => (
-				<a class:list={["site-header__link", { "site-header__link--active": isNavItemActive(item.href) }]} href={item.href} aria-current={isNavItemActive(item.href) ? "page" : undefined}>
+				<a class="site-header__link" data-nav-link data-href={item.href} href={item.href}>
 					{item.label}
 				</a>
 			))
 		}
 	</nav>
 
-	<a class="site-header__cta" href={header.cta.href}>{header.cta.label}</a>
+	<a class="site-header__cta" href={header.cta.href}>
+		{header.cta.label}
+	</a>
 
 	<details class="site-header__mobile-menu" data-mobile-menu>
 		<summary
@@ -54,19 +37,16 @@ const isNavItemActive = (href: string) => {
 		>
 			<span class="site-header__mobile-icon" aria-hidden="true">
 				<Menu class="site-header__mobile-icon-glyph site-header__mobile-icon-glyph--menu" width={30} height={30} stroke-width={3} />
+
 				<X class="site-header__mobile-icon-glyph site-header__mobile-icon-glyph--close" width={30} height={30} stroke-width={3} />
 			</span>
 		</summary>
+
 		<div class="site-header__mobile-panel" data-mobile-panel>
 			<nav class="site-header__mobile-nav" aria-label={header.navAriaLabel}>
 				{
 					header.navItems.map(item => (
-						<a
-							class:list={["site-header__mobile-link", { "site-header__mobile-link--active": isNavItemActive(item.href) }]}
-							data-mobile-menu-link
-							href={item.href}
-							aria-current={isNavItemActive(item.href) ? "page" : undefined}
-						>
+						<a class="site-header__mobile-link" data-nav-link data-href={item.href} data-mobile-menu-link href={item.href}>
 							{item.label}
 						</a>
 					))
@@ -263,6 +243,48 @@ const isNavItemActive = (href: string) => {
 	document.addEventListener("astro:before-swap", () => {
 		void closeMobileMenu();
 	});
+
+	const normalizePath = (path: string) => path.replace(/\/$/, "") || "/";
+
+	const updateHeaderState = () => {
+		const current = normalizePath(location.pathname);
+
+		if (siteHeader) {
+			siteHeader.classList.toggle("is-visible", current !== "/2026");
+		}
+
+		document.querySelectorAll<HTMLAnchorElement>("[data-nav-link]").forEach(link => {
+			const href = link.dataset.href;
+
+			if (!href) {
+				return;
+			}
+
+			const isAnchor = href.includes("#");
+
+			let active = false;
+
+			if (!isAnchor) {
+				const nav = normalizePath(new URL(href, location.origin).pathname);
+
+				active = nav === "/2026" ? current === nav : current === nav || current.startsWith(`${nav}/`);
+			}
+
+			link.classList.toggle("site-header__link--active", link.classList.contains("site-header__link") && active);
+
+			link.classList.toggle("site-header__mobile-link--active", link.classList.contains("site-header__mobile-link") && active);
+
+			if (active) {
+				link.setAttribute("aria-current", "page");
+			} else {
+				link.removeAttribute("aria-current");
+			}
+		});
+	};
+
+	updateHeaderState();
+
+	document.addEventListener("astro:page-load", updateHeaderState);
 </script>
 
 <style>


### PR DESCRIPTION
## 變更摘要

<!-- 簡短描述這個 PR 改了什麼，以及為什麼需要這次變更。 -->

修復 header 的導航欄在頁面轉換時，沒有重新判斷當前路徑與 highlight 的項目。並且修復了課表頁面被忽略的問題。

## 變更類型

- [x] 頁面或元件更新
- [ ] 內容或資料更新 (`src/data`)
- [ ] 圖片、字型或靜態資源更新 (`src/assets` 或 `public`)
- [x] 樣式、layout 或動畫更新
- [ ] SEO、metadata、sitemap 或 manifest 更新
- [ ] Build、CI、deploy 或 tooling 更新

## 關聯 Issue

<!-- 連結相關 issue，例如：Closes #123 -->

## 驗證

- [x] `pnpm build`
- [x] `pnpm lint`
- [x] `pnpm prettier:check`
- [x] 已使用 `pnpm run dev` 檢查相關頁面
- [x] 若有 UI 變更，已檢查 RWD 顯示
- [x] 若有公開內容更新，已確認內容正確且可公開

## 截圖或錄影

<!-- 若有視覺變更，請附上 before/after 截圖或錄影。沒有則可留空。 -->

## Reviewer 注意事項

<!-- 補充高風險區塊、後續事項、部署注意事項，或希望 reviewer 特別看的地方。 -->

因為判斷路徑的 script 已從 frontmatter 移到 <script />，請協助確認沒有誤刪到其他功能。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized navigation active state handling to improve performance and page load behavior. Navigation links continue to display the currently active page indicator as expected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sitcon-tw/camp2026/pull/132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->