### PR TITLE
Feat: add date to schedule

### DIFF
--- a/src/components/SchedulePreview.astro
+++ b/src/components/SchedulePreview.astro
@@ -174,7 +174,7 @@ const getRenderableBlocks = (day: ScheduleDay) => {
 												index === 0 ? [<span class="schedule-day__title-entry">{entry}</span>] : [<wbr />, <span class="schedule-day__title-entry">{entry}</span>]
 											)}
 										</h2>
-										<p class="schedule-day__subtitle">{day.subtitle}</p>
+										<p class="schedule-day__subtitle">{day.subtitle}<span class="schedule-day__date"> - {day.date}</span></p>
 									</div>
 								</header>
 
@@ -632,6 +632,7 @@ const getRenderableBlocks = (day: ScheduleDay) => {
 	}
 
 	.schedule-day__subtitle,
+	.schedule-day__date,
 	.schedule-day__title {
 		margin: 0;
 	}
@@ -643,6 +644,13 @@ const getRenderableBlocks = (day: ScheduleDay) => {
 		opacity: 0.82;
 	}
 
+	.schedule-day__date {
+		font-size: clamp(0.68rem, 0.8vw, 0.82rem);
+		font-weight: 800;
+		line-height: 1.2;
+		opacity: 0.7;
+	}
+	
 	.schedule-day__title {
 		font-size: clamp(1.25rem, 1.65vw, 1.72rem);
 		font-weight: 800;

--- a/src/components/SchedulePreview.astro
+++ b/src/components/SchedulePreview.astro
@@ -174,7 +174,10 @@ const getRenderableBlocks = (day: ScheduleDay) => {
 												index === 0 ? [<span class="schedule-day__title-entry">{entry}</span>] : [<wbr />, <span class="schedule-day__title-entry">{entry}</span>]
 											)}
 										</h2>
-										<p class="schedule-day__subtitle">{day.subtitle}<span class="schedule-day__date"> - {day.date}</span></p>
+										<p class="schedule-day__subtitle">
+											{day.subtitle}
+											<span class="schedule-day__date"> - {day.date}</span>
+										</p>
 									</div>
 								</header>
 
@@ -650,7 +653,7 @@ const getRenderableBlocks = (day: ScheduleDay) => {
 		line-height: 1.2;
 		opacity: 0.7;
 	}
-	
+
 	.schedule-day__title {
 		font-size: clamp(1.25rem, 1.65vw, 1.72rem);
 		font-weight: 800;

--- a/src/data/schedule.ts
+++ b/src/data/schedule.ts
@@ -21,6 +21,7 @@ export interface ScheduleBlock {
 export interface ScheduleDay {
 	id: string;
 	title: string[];
+	date: string;
 	subtitle: string;
 	type: ScheduleDayType;
 	blocks: ScheduleBlock[];
@@ -307,6 +308,7 @@ export const scheduleDays: ScheduleDay[] = [
 		id: "day-one",
 		// Each title item is a wrap unit: keep words together, and only wrap between items when needed.
 		title: ["主線課程", "先導日"],
+		date: "7/8",
 		subtitle: "Day 1",
 		type: "opening",
 		blocks: [
@@ -323,6 +325,7 @@ export const scheduleDays: ScheduleDay[] = [
 	{
 		id: "day-two",
 		title: ["軟體工程", "主題日"],
+		date: "7/9",
 		subtitle: "Day 2",
 		type: "software",
 		blocks: [
@@ -338,6 +341,7 @@ export const scheduleDays: ScheduleDay[] = [
 		id: "day-three",
 		title: ["人工智慧", "主題日"],
 		subtitle: "Day 3",
+		date: "7/10",
 		type: "artificial-intelligence",
 		blocks: [
 			{ startSlot: "9:00", span: 3, eventId: "ml-main" },
@@ -352,6 +356,7 @@ export const scheduleDays: ScheduleDay[] = [
 	{
 		id: "day-four",
 		title: ["資訊安全", "主題日"],
+		date: "7/11",
 		subtitle: "Day 4",
 		type: "security",
 		blocks: [
@@ -367,6 +372,7 @@ export const scheduleDays: ScheduleDay[] = [
 	{
 		id: "day-five",
 		title: ["資訊交流", "探索日"],
+		date: "7/12",
 		subtitle: "Day 5",
 		type: "closing",
 		blocks: [


### PR DESCRIPTION
## 變更摘要

<!-- 簡短描述這個 PR 改了什麼，以及為什麼需要這次變更。 -->

## 變更類型

- [x] 頁面或元件更新
- [ ] 內容或資料更新 (`src/data`)
- [ ] 圖片、字型或靜態資源更新 (`src/assets` 或 `public`)
- [ ] 樣式、layout 或動畫更新
- [ ] SEO、metadata、sitemap 或 manifest 更新
- [ ] Build、CI、deploy 或 tooling 更新

## 關聯 Issue

許願一下，可以在課表上加上日期嗎
剛剛在戳東西發現課表沒日期好難對應
https://sitcon.camp/2026/schedule/

## 驗證

- [x] `pnpm build`
- [x] `pnpm lint`
- [x] `pnpm prettier:check`
- [x] 已使用 `pnpm run dev` 檢查相關頁面
- [x] 若有 UI 變更，已檢查 RWD 顯示
- [x] 若有公開內容更新，已確認內容正確且可公開

## 截圖或錄影

<img width="1251" height="192" alt="image" src="https://github.com/user-attachments/assets/06d8dd85-e9a1-43f9-96e8-29858917150a" />


## Reviewer 注意事項


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Schedule now displays corresponding dates in headers alongside day titles and subtitles. Each day (7/8 through 7/12) is clearly labeled with both its title and date.

* **Style**
  * Updated visual styling to ensure date information is appropriately formatted and readable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->