### PR TITLE
Fix: x asix overflow problem

### DIFF
--- a/src/components/MasterCarousel.astro
+++ b/src/components/MasterCarousel.astro
@@ -60,7 +60,7 @@ const getMemberImage = (member: Member) => {
 	</div>
 
 	<div
-		class="master-marquee-viewport mt-(--gap) flex w-screen overflow-x-auto overflow-y-hidden overscroll-x-contain focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-current"
+		class="master-marquee-viewport mt-(--gap) flex w-full overflow-x-auto overflow-y-hidden overscroll-x-contain focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-current"
 		data-master-marquee-viewport
 		role="region"
 		aria-label={masterCarousel.sectionTitle}

--- a/src/components/MasterClass.astro
+++ b/src/components/MasterClass.astro
@@ -468,6 +468,7 @@ const getMasterImage = (masterClass: MasterClassItem) => {
 		--master-controls-offset: clamp(0.75rem, 2vw, 1.25rem);
 		--master-controls-reserved: 0.9rem;
 		position: relative;
+		overflow-x: clip;
 		padding-block: 0 clamp(4.5rem, 9vw, 8rem);
 		scroll-margin-block-start: calc(5.5rem + env(safe-area-inset-top, 0px));
 		background: var(--color-background);


### PR DESCRIPTION
## 變更摘要

<!-- 簡短描述這個 PR 改了什麼，以及為什麼需要這次變更。 -->

## 變更類型

- [ ] 頁面或元件更新
- [ ] 內容或資料更新 (`src/data`)
- [ ] 圖片、字型或靜態資源更新 (`src/assets` 或 `public`)
- [x] 樣式、layout 或動畫更新
- [ ] SEO、metadata、sitemap 或 manifest 更新
- [ ] Build、CI、deploy 或 tooling 更新

## 關聯 Issue

<!-- 連結相關 issue，例如：Closes #123 -->

## 驗證

- [x] `pnpm build`
- [x] `pnpm lint`
- [x] `pnpm prettier:check`
- [x] 已使用 `pnpm run dev` 檢查相關頁面
- [x] 若有 UI 變更，已檢查 RWD 顯示
- [x] 若有公開內容更新，已確認內容正確且可公開

## 截圖或錄影

> Before
<img width="2110" height="376" alt="image" src="https://github.com/user-attachments/assets/06c21572-0370-4720-971b-269fc87b3297" />

> After
https://cb80ec6e-camp2026.yorucute.workers.dev

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated carousel viewport width configuration for improved layout behavior
  * Enhanced horizontal overflow handling in the master class component for better visual containment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->