### PR TITLE
feat: 廣度課程講者資料

### DIFF
--- a/src/components/SchedulePreview.astro
+++ b/src/components/SchedulePreview.astro
@@ -328,6 +328,7 @@ const interactiveScheduleEvents = scheduleEvents.filter(event => event.isInterac
 										{speakers.map(speaker => {
 											const avatar = getSpeakerAvatar(speaker);
 											const avatarAlt = speaker.avatar?.alt ?? speaker.name ?? "";
+											const speakerDescription = speaker.description?.trim();
 
 											return (
 												<article class="schedule-speaker">
@@ -340,7 +341,7 @@ const interactiveScheduleEvents = scheduleEvents.filter(event => event.isInterac
 													)}
 													<div class="schedule-speaker__content">
 														{speaker.name?.trim() && <h3 class="schedule-speaker__name">{speaker.name}</h3>}
-														{speaker.description?.trim() && <p class="schedule-speaker__description">{speaker.description}</p>}
+														<p class:list={["schedule-speaker__description", { "schedule-speaker__description--pending": !speakerDescription }]}>{speakerDescription || "講者介紹即將公開"}</p>
 													</div>
 												</article>
 											);
@@ -1110,7 +1111,7 @@ const interactiveScheduleEvents = scheduleEvents.filter(event => event.isInterac
 		display: grid;
 		grid-template-columns: auto minmax(0, 1fr);
 		gap: 0.85rem;
-		align-items: start;
+		align-items: center;
 		padding: 0.9rem;
 		color: var(--color-background);
 		background: rgb(249 245 239 / 8%);
@@ -1155,6 +1156,11 @@ const interactiveScheduleEvents = scheduleEvents.filter(event => event.isInterac
 		font-size: 0.92rem;
 		font-weight: 700;
 		line-height: 1.6;
+	}
+
+	.schedule-speaker__description--pending {
+		color: color-mix(in srgb, var(--color-background) 52%, transparent);
+		font-size: 0.88rem;
 	}
 
 	.schedule-dialog__close {

--- a/src/components/SchedulePreview.astro
+++ b/src/components/SchedulePreview.astro
@@ -5,6 +5,7 @@ import Info from "~icons/lucide/info";
 import X from "~icons/lucide/x";
 import type { ScheduleBlock, ScheduleDay, ScheduleDayType, ScheduleEvent, ScheduleEventCategory, ScheduleSpeaker } from "@/data/schedule";
 import { scheduleDays, scheduleEvents, scheduleMeta, scheduleSlots, scheduleSpeakers } from "@/data/schedule";
+import { renderMarkdown } from "@/utils/markdown";
 
 const scheduleImageModules = import.meta.glob<{ default: ImageMetadata }>("../assets/schedule/*.{jpg,jpeg,png,webp}", { eager: true });
 const scheduleImages = new Map(
@@ -100,6 +101,15 @@ const hasEventDetails = (event: ScheduleEvent): boolean => {
 	const descriptionLines = event.description ?? [];
 	return Boolean(event.image?.key || descriptionLines.some(line => line.trim()) || getEventSpeakers(event).length > 0);
 };
+
+const descriptionLinesToMarkdown = (lines: string[]): string =>
+	lines.reduce((markdown, line) => {
+		const previousLine = markdown.split("\n").at(-1) ?? "";
+		const joinsList = /^[-*+]\s+/.test(line) && /^[-*+]\s+/.test(previousLine);
+		const separator = joinsList ? "\n" : "\n\n";
+
+		return markdown ? `${markdown}${separator}${line}` : line;
+	}, "");
 
 const getBlockSpan = (block: ScheduleBlock): number => {
 	const startIndex = scheduleSlotIndexMap.get(block.startSlot);
@@ -312,16 +322,7 @@ const interactiveScheduleEvents = scheduleEvents.filter(event => event.isInterac
 								<h2 id={`schedule-dialog-title-${event.id}`} class="schedule-dialog__title" tabindex="-1">
 									{event.name}
 								</h2>
-								{descriptionLines.some(line => line.trim()) && (
-									<p class="schedule-dialog__description">
-										{descriptionLines.map((line, index) => (
-											<>
-												{line}
-												{index < descriptionLines.length - 1 && <br />}
-											</>
-										))}
-									</p>
-								)}
+								{descriptionLines.some(line => line.trim()) && <div class="schedule-dialog__description" set:html={renderMarkdown(descriptionLinesToMarkdown(descriptionLines))} />}
 								{speakers.length > 0 && (
 									<section class="schedule-dialog__speakers" aria-label={`${event.name}講者`}>
 										{speakers.map(speaker => {
@@ -991,9 +992,9 @@ const interactiveScheduleEvents = scheduleEvents.filter(event => event.isInterac
 		box-sizing: border-box;
 		width: min(100%, 58rem);
 		max-width: 100%;
-		max-height: calc(100dvh - 2rem);
+		height: min(43rem, calc(100dvh - 4rem));
+		max-height: calc(100dvh - 4rem);
 		overflow: hidden;
-		overflow-y: auto;
 		background: var(--color-foreground);
 		border: 3px solid var(--color-background);
 		border-radius: 1.5rem;
@@ -1021,9 +1022,10 @@ const interactiveScheduleEvents = scheduleEvents.filter(event => event.isInterac
 	.schedule-dialog__content {
 		display: flex;
 		flex-direction: column;
-		justify-content: center;
 		gap: 1rem;
 		min-width: 0;
+		min-height: 0;
+		overflow-y: auto;
 		padding: clamp(1.5rem, 4vw, 3rem);
 	}
 
@@ -1042,6 +1044,59 @@ const interactiveScheduleEvents = scheduleEvents.filter(event => event.isInterac
 		font-size: clamp(1rem, 1.6vw, 1.18rem);
 		font-weight: 700;
 		line-height: 1.75;
+	}
+
+	.schedule-dialog__description :global(:first-child) {
+		margin-top: 0;
+	}
+
+	.schedule-dialog__description :global(:last-child) {
+		margin-bottom: 0;
+	}
+
+	.schedule-dialog__description :global(p) {
+		margin-block: 0.75rem;
+	}
+
+	.schedule-dialog__description :global(ul),
+	.schedule-dialog__description :global(ol) {
+		display: grid;
+		gap: 0.45rem;
+		margin-block: 0.85rem;
+		padding-inline-start: 0;
+		list-style: none;
+	}
+
+	.schedule-dialog__description :global(li) {
+		position: relative;
+		padding-inline-start: 1.35rem;
+	}
+
+	.schedule-dialog__description :global(li::before) {
+		position: absolute;
+		inset-block-start: 0.72em;
+		inset-inline-start: 0;
+		width: 0.46rem;
+		aspect-ratio: 1;
+		background: var(--color-orange);
+		border: 1px solid color-mix(in srgb, var(--color-background) 60%, transparent);
+		border-radius: 999rem;
+		box-shadow: 0.08rem 0.08rem 0 0 rgb(0 0 0 / 30%);
+		content: "";
+	}
+
+	.schedule-dialog__description :global(a) {
+		color: var(--color-sky-blue);
+		text-decoration: underline;
+		text-decoration-thickness: 0.1em;
+		text-underline-offset: 0.18em;
+	}
+
+	.schedule-dialog__description :global(code) {
+		padding: 0.08rem 0.3rem;
+		color: var(--color-background);
+		background: rgb(249 245 239 / 12%);
+		border-radius: 0.35rem;
 	}
 
 	.schedule-dialog__speakers {
@@ -1394,6 +1449,7 @@ const interactiveScheduleEvents = scheduleEvents.filter(event => event.isInterac
 		.schedule-dialog__panel {
 			width: 100%;
 			max-width: 32rem;
+			height: auto;
 			grid-template-columns: 1fr;
 			max-height: calc(100dvh - 2rem);
 			overflow-y: auto;
@@ -1406,6 +1462,7 @@ const interactiveScheduleEvents = scheduleEvents.filter(event => event.isInterac
 		}
 
 		.schedule-dialog__content {
+			overflow-y: visible;
 			padding: 1.25rem;
 		}
 	}

--- a/src/components/SchedulePreview.astro
+++ b/src/components/SchedulePreview.astro
@@ -3,8 +3,8 @@ import type { ImageMetadata } from "astro";
 import { Image } from "astro:assets";
 import Info from "~icons/lucide/info";
 import X from "~icons/lucide/x";
-import type { ScheduleBlock, ScheduleDay, ScheduleDayType, ScheduleEvent, ScheduleEventCategory } from "@/data/schedule";
-import { scheduleDays, scheduleEvents, scheduleMeta, scheduleSlots } from "@/data/schedule";
+import type { ScheduleBlock, ScheduleDay, ScheduleDayType, ScheduleEvent, ScheduleEventCategory, ScheduleSpeaker } from "@/data/schedule";
+import { scheduleDays, scheduleEvents, scheduleMeta, scheduleSlots, scheduleSpeakers } from "@/data/schedule";
 
 const scheduleImageModules = import.meta.glob<{ default: ImageMetadata }>("../assets/schedule/*.{jpg,jpeg,png,webp}", { eager: true });
 const scheduleImages = new Map(
@@ -14,11 +14,19 @@ const scheduleImages = new Map(
 		return [key, mod.default];
 	})
 );
+const speakerAvatarModules = import.meta.glob<{ default: ImageMetadata }>(["../assets/speakers/*.{jpg,jpeg,png,webp}", "../assets/feature-members/*.{jpg,jpeg,png,webp}"], { eager: true });
+const speakerAvatars = new Map(
+	Object.entries(speakerAvatarModules).map(([path, mod]) => {
+		const filename = path.split("/").pop() ?? path;
+		const key = filename.replace(/\.(jpe?g|png|webp)$/i, "");
+		return [key, mod.default];
+	})
+);
 
 const eventsById = new Map(scheduleEvents.map(event => [event.id, event]));
+const speakersById = new Map(scheduleSpeakers.map(speaker => [speaker.id, speaker]));
 const scheduleSlotIndexMap = new Map(scheduleSlots.map((slot, index) => [slot, index]));
 const scheduleSlotCount = scheduleSlots.length;
-const interactiveScheduleEvents = scheduleEvents.filter(event => event.isInteractive === true && event.description && event.image);
 
 const dayAccentClassMap: Record<ScheduleDayType, string> = {
 	opening: "schedule-day--sky",
@@ -47,11 +55,11 @@ const getEvent = (eventId: string): ScheduleEvent => {
 	return event;
 };
 
-const getScheduleImage = (event: ScheduleEvent): ImageMetadata => {
+const getScheduleImage = (event: ScheduleEvent): ImageMetadata | undefined => {
 	const imageKey = event.image?.key;
 
 	if (!imageKey) {
-		throw new Error(`Missing schedule image key: ${event.id}`);
+		return undefined;
 	}
 
 	const image = scheduleImages.get(imageKey);
@@ -61,6 +69,36 @@ const getScheduleImage = (event: ScheduleEvent): ImageMetadata => {
 	}
 
 	return image;
+};
+
+const getSpeakerAvatar = (speaker: ScheduleSpeaker): ImageMetadata | undefined => {
+	const avatarKey = speaker.avatar?.key;
+
+	if (!avatarKey) {
+		return undefined;
+	}
+
+	return speakerAvatars.get(avatarKey);
+};
+
+const hasSpeakerContent = (speaker: ScheduleSpeaker): boolean => Boolean(speaker.name?.trim() || speaker.description?.trim() || speaker.avatar?.key?.trim());
+
+const getEventSpeakers = (event: ScheduleEvent): ScheduleSpeaker[] =>
+	(event.speakers ?? [])
+		.map(speakerId => {
+			const speaker = speakersById.get(speakerId);
+
+			if (!speaker) {
+				throw new Error(`Missing schedule speaker: ${speakerId}`);
+			}
+
+			return speaker;
+		})
+		.filter(hasSpeakerContent);
+
+const hasEventDetails = (event: ScheduleEvent): boolean => {
+	const descriptionLines = event.description ?? [];
+	return Boolean(event.image?.key || descriptionLines.some(line => line.trim()) || getEventSpeakers(event).length > 0);
 };
 
 const getBlockSpan = (block: ScheduleBlock): number => {
@@ -113,7 +151,7 @@ const getRenderableBlocks = (day: ScheduleDay) => {
 		return {
 			...block,
 			event,
-			isInteractive: event.isInteractive === true && Boolean(event.description && event.image),
+			isInteractive: event.isInteractive === true && hasEventDetails(event),
 			label: getBlockRangeLabel(block),
 			rowStart: startIndex + 2,
 			span
@@ -138,6 +176,8 @@ const getRenderableBlocks = (day: ScheduleDay) => {
 
 	return [...blocks, ...emptyBlocks].sort((left, right) => left.rowStart - right.rowStart);
 };
+
+const interactiveScheduleEvents = scheduleEvents.filter(event => event.isInteractive === true && hasEventDetails(event));
 ---
 
 <section class="schedule-page" aria-labelledby="schedule-title">
@@ -249,25 +289,63 @@ const getRenderableBlocks = (day: ScheduleDay) => {
 					const descriptionLines = event.description ?? [];
 					const image = getScheduleImage(event);
 					const imageAlt = event.image?.alt ?? "";
+					const speakers = getEventSpeakers(event);
 
 					return (
-						<div class="schedule-dialog__panel">
-							<div class="schedule-dialog__image-wrap">
-								<Image class="schedule-dialog__image" src={image} alt={imageAlt} loading="lazy" decoding="async" format="webp" widths={[640, 960, 1280, 1600]} sizes="(max-width: 72rem) 100vw, 52vw" />
-							</div>
+						<div class:list={["schedule-dialog__panel", { "schedule-dialog__panel--no-image": !image }]}>
+							{image && (
+								<div class="schedule-dialog__image-wrap">
+									<Image
+										class="schedule-dialog__image"
+										src={image}
+										alt={imageAlt}
+										loading="lazy"
+										decoding="async"
+										format="webp"
+										widths={[640, 960, 1280, 1600]}
+										sizes="(max-width: 72rem) 100vw, 52vw"
+									/>
+								</div>
+							)}
 							<div class="schedule-dialog__content">
 								<span class:list={["schedule-dialog__badge", categoryClassMap[event.category]]}>{event.category}</span>
 								<h2 id={`schedule-dialog-title-${event.id}`} class="schedule-dialog__title" tabindex="-1">
 									{event.name}
 								</h2>
-								<p class="schedule-dialog__description">
-									{descriptionLines.map((line, index) => (
-										<>
-											{line}
-											{index < descriptionLines.length - 1 && <br />}
-										</>
-									))}
-								</p>
+								{descriptionLines.some(line => line.trim()) && (
+									<p class="schedule-dialog__description">
+										{descriptionLines.map((line, index) => (
+											<>
+												{line}
+												{index < descriptionLines.length - 1 && <br />}
+											</>
+										))}
+									</p>
+								)}
+								{speakers.length > 0 && (
+									<section class="schedule-dialog__speakers" aria-label={`${event.name}講者`}>
+										{speakers.map(speaker => {
+											const avatar = getSpeakerAvatar(speaker);
+											const avatarAlt = speaker.avatar?.alt ?? speaker.name ?? "";
+
+											return (
+												<article class="schedule-speaker">
+													{avatar ? (
+														<Image class="schedule-speaker__avatar" src={avatar} alt={avatarAlt} loading="lazy" decoding="async" format="webp" width={72} height={72} />
+													) : (
+														<div class="schedule-speaker__avatar schedule-speaker__avatar--placeholder" aria-hidden="true">
+															{speaker.name?.trim().charAt(0) ?? ""}
+														</div>
+													)}
+													<div class="schedule-speaker__content">
+														{speaker.name?.trim() && <h3 class="schedule-speaker__name">{speaker.name}</h3>}
+														{speaker.description?.trim() && <p class="schedule-speaker__description">{speaker.description}</p>}
+													</div>
+												</article>
+											);
+										})}
+									</section>
+								)}
 							</div>
 							<button type="button" class="schedule-dialog__close" data-schedule-dialog-close aria-label={`關閉${event.name}介紹`}>
 								<X width={24} height={24} stroke-width={3} />
@@ -922,6 +1000,11 @@ const getRenderableBlocks = (day: ScheduleDay) => {
 		box-shadow: 0.4rem 0.4rem 0 0 var(--color-orange);
 	}
 
+	.schedule-dialog__panel--no-image {
+		grid-template-columns: minmax(0, 1fr);
+		width: min(100%, 42rem);
+	}
+
 	.schedule-dialog__image-wrap {
 		order: 2;
 		min-height: 25rem;
@@ -959,6 +1042,64 @@ const getRenderableBlocks = (day: ScheduleDay) => {
 		font-size: clamp(1rem, 1.6vw, 1.18rem);
 		font-weight: 700;
 		line-height: 1.75;
+	}
+
+	.schedule-dialog__speakers {
+		display: grid;
+		gap: 0.85rem;
+		margin-top: auto;
+		padding-top: 0.25rem;
+	}
+
+	.schedule-speaker {
+		display: grid;
+		grid-template-columns: auto minmax(0, 1fr);
+		gap: 0.85rem;
+		align-items: start;
+		padding: 0.9rem;
+		color: var(--color-background);
+		background: rgb(249 245 239 / 8%);
+		border: 2px solid rgb(249 245 239 / 14%);
+		border-radius: 1rem;
+	}
+
+	.schedule-speaker__avatar {
+		display: block;
+		width: 3.5rem;
+		aspect-ratio: 1;
+		object-fit: cover;
+		background: var(--color-soft-blue);
+		border: 2px solid rgb(249 245 239 / 18%);
+		border-radius: 999rem;
+	}
+
+	.schedule-speaker__avatar--placeholder {
+		display: grid;
+		place-items: center;
+		color: var(--color-foreground);
+		font-size: 1.4rem;
+		font-weight: 800;
+		line-height: 1;
+		background: var(--color-green);
+	}
+
+	.schedule-speaker__content {
+		min-width: 0;
+	}
+
+	.schedule-speaker__name {
+		margin: 0;
+		font-size: 1.05rem;
+		font-weight: 800;
+		line-height: 1.3;
+	}
+
+	.schedule-speaker__description {
+		margin: 0.2rem 0 0;
+		color: color-mix(in srgb, var(--color-background) 72%, transparent);
+		font-size: 0.92rem;
+		font-weight: 700;
+		line-height: 1.6;
 	}
 
 	.schedule-dialog__close {

--- a/src/data/schedule.ts
+++ b/src/data/schedule.ts
@@ -18,6 +18,16 @@ export interface ScheduleBlock {
 	eventId: string;
 }
 
+export interface ScheduleSpeaker {
+	id: string;
+	name?: string;
+	description?: string;
+	avatar?: {
+		key?: string;
+		alt?: string;
+	};
+}
+
 export interface ScheduleDay {
 	id: string;
 	title: string[];
@@ -38,12 +48,26 @@ export interface ScheduleEvent {
 		key: string;
 		alt: string;
 	};
+	speakers?: ScheduleSpeaker["id"][];
 }
 
 export const scheduleMeta: ScheduleMeta = {
 	title: "活動日程",
 	description: "SITCON Camp 2026 將圍繞軟體工程、人工智慧與資訊安全三大主線展開，並穿插交流、實作與活動。"
 };
+
+export const scheduleSpeakers: ScheduleSpeaker[] = [
+	{
+		id: "william-mou",
+		name: "William Mou",
+		description:
+			"嗨，我是展佑！我的開發日常是跟電腦底層對話。曾在 Linux Foundation 的 WasmEdge 專案刻過 C/C++ API、在實驗室及 Homelab 建置虛擬機及 Overlay Network，近期在 SiFive 參與 RISC-V CPU 及 AI 加速器的晶片設計及性能最佳化。大學時最瘋狂的經歷是在清大超算隊伍設計 3KW 功耗限制的叢集，贏得兩座世界超級電腦冠軍（SCC22 & ASC20-21）回台灣。\n身為 2019 Camp 的學員，這次回來想和大家聊聊「被 AI 取代」的焦慮，分享資工系那些 Hardcore 的底層知識，如何成為你走過每次技術革命的心法。"
+	},
+	{
+		id: "chieh-ying-li",
+		name: "李杰穎"
+	}
+];
 
 export const scheduleEvents: ScheduleEvent[] = [
 	{
@@ -61,14 +85,19 @@ export const scheduleEvents: ScheduleEvent[] = [
 	{
 		id: "broad-course",
 		name: "廣度課程",
-		summary: "敬請期待...",
-		description: ["即將揭曉..."],
+		summary: "從應用層往下看底層系統與高效能運算，理解 AI 時代仍然重要的資工基礎。",
+		description: [
+			"當 LLM 幾秒鐘就能生成精美的 Web UI、AI 寫 Code 的速度遠超人類，你是否曾看著資工系厚重的「作業系統」、「計算機組織與結構」課本，懷疑起學這些底層理論的意義？這場廣度課程希望帶領已經具備基礎程式能力的你，把目光從喧囂的「應用層」往下切，直達整座資訊世界的地基——底層系統與高效能運算（HPC）。身為曾經坐在台下的 2019 Camp 學員，我想結合近年的實戰經驗，跟大家聊聊：",
+			"- 打破黑盒： 在超級電腦上跑動大型 AI 模型的背後，撐起算力奇蹟的從來不是魔法，而是作業系統與硬體架構的極致調度。那些讓你熬夜趕工的資工必修課，究竟在當代最前沿的技術裡扮演什麼角色？",
+			"- 造浪者的心法： 當寫出會動的 Code 門檻被無限拉低，我們該如何省思資工系帶給我們的思維方式，從單純的技術消費者，蛻變成參與下一次革命的貢獻者？"
+		],
 		category: "其他",
 		isInteractive: true,
 		image: {
 			key: "broad-course",
 			alt: "廣度課程活動現場"
-		}
+		},
+		speakers: ["william-mou", "chieh-ying-li"]
 	},
 	{
 		id: "quest",


### PR DESCRIPTION
## 變更摘要

更新 `/schedule` 以包含廣度課程的相關資訊

## 變更類型

- [x] 頁面或元件更新
- [  內容或資料更新 (`src/data`)
- [x] 圖片、字型或靜態資源更新 (`src/assets` 或 `public`)
- [ ] 樣式、layout 或動畫更新
- [ ] SEO、metadata、sitemap 或 manifest 更新
- [ ] Build、CI、deploy 或 tooling 更新

## 關聯 Issue

<!-- 連結相關 issue，例如：Closes #123 -->

## 驗證

- [x] `pnpm build`
- [x] `pnpm lint`
- [x] `pnpm prettier:check`
- [x] 已使用 `pnpm run dev` 檢查相關頁面
- [x] 若有 UI 變更，已檢查 RWD 顯示
- [x] 若有公開內容更新，已確認內容正確且可公開


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Schedule events can now show speaker avatars and speaker details in the event dialog.
  * Event descriptions support richer formatting, including lists, links, and inline code.

* **Bug Fixes**
  * Events with incomplete image data no longer break schedule rendering.
  * Interactive events now appear when they have a valid image, description, or speaker content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->