### PR TITLE
修復展示影片在網頁載入後15秒內不能點的問題

### DIFF
--- a/src/components/StudentComment.astro
+++ b/src/components/StudentComment.astro
@@ -109,7 +109,7 @@ const videos = studentComment.video.map(video => {
 		<div class="marquee-track flex w-max" data-video-marquee-track>
 			{
 				[0, 1, 2].map(groupIndex => (
-					<div class="marquee-group flex shrink-0 gap-4 pr-4" data-marquee-group aria-hidden={groupIndex > 0 ? "true" : undefined} inert={groupIndex > 0 ? true : undefined}>
+					<div class="marquee-group flex shrink-0 gap-4 pr-4" data-marquee-group aria-hidden={groupIndex > 0 ? "true" : undefined}>
 						{videos.map(v => (
 							<button
 								type="button"
@@ -356,7 +356,7 @@ const videos = studentComment.video.map(video => {
 
 				groupWidth = groups[0]?.scrollWidth ?? 0;
 				if (!didSetInitialScroll && groupWidth) {
-					viewport.scrollLeft = groupWidth;
+					viewport.scrollLeft = groupWidth * 0.5;
 					didSetInitialScroll = true;
 				} else {
 					normalizeVideoScroll();


### PR DESCRIPTION
## 變更摘要
修復展示影片在網頁載入後15秒內不能點的問題

<!-- 簡短描述這個 PR 改了什麼，以及為什麼需要這次變更。 -->

## 變更類型

- [x] 頁面或元件更新
- [ ] 內容或資料更新 (`src/data`)
- [ ] 圖片、字型或靜態資源更新 (`src/assets` 或 `public`)
- [ ] 樣式、layout 或動畫更新
- [ ] SEO、metadata、sitemap 或 manifest 更新
- [ ] Build、CI、deploy 或 tooling 更新

## 關聯 Issue

<!-- 連結相關 issue，例如：Closes #123 -->

## 驗證

- [x] `pnpm build`
- [x] `pnpm lint`
- [ ] `pnpm prettier:check`
- [x] 已使用 `pnpm run dev` 檢查相關頁面
- [ ] 若有 UI 變更，已檢查 RWD 顯示
- [ ] 若有公開內容更新，已確認內容正確且可公開

## 截圖或錄影

<!-- 若有視覺變更，請附上 before/after 截圖或錄影。沒有則可留空。 -->

## Reviewer 注意事項

<!-- 補充高風險區塊、後續事項、部署注意事項，或希望 reviewer 特別看的地方。 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the video marquee behavior so offscreen groups remain interactive and the initial scroll position starts more smoothly.
  * Fixed the marquee setup to reduce abrupt jumps when the carousel first loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->