### PR TITLE
feat: replace event with broad lecture

### DIFF
--- a/src/data/schedule.ts
+++ b/src/data/schedule.ts
@@ -169,6 +169,13 @@ export const scheduleEvents: ScheduleEvent[] = [
 		}
 	},
 	{
+		id: "ml-broad",
+		name: "人工智慧廣度課程",
+		summary: "從更廣的視角認識人工智慧，建立對領域全貌的整體理解。",
+		category: "其他",
+		isInteractive: true
+	},
+	{
 		id: "security-main",
 		name: "資安主線課程",
 		summary: "從攻防視角理解系統安全與資安思維。",
@@ -376,9 +383,9 @@ export const scheduleDays: ScheduleDay[] = [
 			{ startSlot: "9:00", span: 3, eventId: "ml-main" },
 			{ startSlot: "12:00", eventId: "lunch" },
 			{ startSlot: "13:00", span: 3, eventId: "ml-main" },
-			{ startSlot: "16:00", span: 2, eventId: "heisenbug" },
-			{ startSlot: "18:00", eventId: "dinner" },
-			{ startSlot: "19:00", span: 2, eventId: "ml-main" },
+			{ startSlot: "16:00", eventId: "ml-broad" },
+			{ startSlot: "17:00", eventId: "dinner" },
+			{ startSlot: "18:00", span: 3, eventId: "ml-main" },
 			{ startSlot: "21:00", eventId: "sigs-ak" }
 		]
 	},


### PR DESCRIPTION
## 變更摘要

將位元城活動取代為 AI 廣度課程

## 變更類型

- [ ] 頁面或元件更新
- [X] 內容或資料更新 (`src/data`)
- [ ] 圖片、字型或靜態資源更新 (`src/assets` 或 `public`)
- [ ] 樣式、layout 或動畫更新
- [ ] SEO、metadata、sitemap 或 manifest 更新
- [ ] Build、CI、deploy 或 tooling 更新

## 關聯 Issue



## 驗證

- [X] `pnpm build`
- [X] `pnpm lint`
- [X] `pnpm prettier:check`
- [X] 已使用 `pnpm run dev` 檢查相關頁面
- [ ] 若有 UI 變更，已檢查 RWD 顯示
- [ ] 若有公開內容更新，已確認內容正確且可公開

## 截圖或錄影



## Reviewer 注意事項




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new interactive schedule session for “人工智慧廣度課程”.
  * Updated the day-three agenda with revised late-afternoon and evening session times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->